### PR TITLE
Handle spaces in dSYM path

### DIFF
--- a/bin/bugsnag-dsym-upload
+++ b/bin/bugsnag-dsym-upload
@@ -77,7 +77,7 @@ if [[ ! -d $dsym_dir ]]; then
     exit_with_usage "'$dsym_dir' is not a directory"
 fi
 
-# Set IFS to handle spaces in the dDSYM path when looping through dSYM files
+# Set IFS to ensure that file paths with spaces in get processed correctly
 IFS=$'\n'
 
 for dsym in $dsym_dir/*.dSYM; do

--- a/bin/bugsnag-dsym-upload
+++ b/bin/bugsnag-dsym-upload
@@ -77,6 +77,9 @@ if [[ ! -d $dsym_dir ]]; then
     exit_with_usage "'$dsym_dir' is not a directory"
 fi
 
+# Set IFS to handle spaces in the dDSYM path when looping through dSYM files
+IFS=$'\n'
+
 for dsym in $dsym_dir/*.dSYM; do
     log_verbose "Preparing to upload $dsym"
 


### PR DESCRIPTION
Fixes an issue with dSYM files failing to upload if the path contains spaces